### PR TITLE
Recreate beamer issue with version 1.2

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -6,15 +6,15 @@ import 'package:beamer_test/widgets/foo.dart';
 import 'package:flutter/cupertino.dart';
 
 class AppRouter {
-  static const dashboardRoute = '*';
+  static const _prefix = '/dashboard';
+  static const dashboardRoute = '$_prefix/*';
   static const dialogRoute = '/dialog';
-  static const fooRoute = '/foo';
-  static const barRoute = '/bar';
+  static const fooRoute = '$_prefix/foo';
+  static const barRoute = '$_prefix/bar';
 
   static final routeInformationParser = BeamerParser();
   static final routerDelegate = BeamerDelegate(
     initialPath: fooRoute,
-    // transitionDelegate: const NoAnimationTransitionDelegate(),
     locationBuilder: RoutesLocationBuilder(
       routes: {
         dashboardRoute: (
@@ -27,6 +27,8 @@ class AppRouter {
           return BeamPage(
             child: Dashboard(
               routerDelegate: BeamerDelegate(
+                initialPath: fooRoute,
+                updateFromParent: false,
                 transitionDelegate: const NoAnimationTransitionDelegate(),
                 locationBuilder: RoutesLocationBuilder(
                   routes: {
@@ -55,6 +57,7 @@ class AppRouter {
           data,
         ) =>
             const BeamPage(
+              fullScreenDialog: true,
               key: const ValueKey('dialog'),
               child: const DialogScreen(),
             ),

--- a/lib/widgets/bottom_navigation.dart
+++ b/lib/widgets/bottom_navigation.dart
@@ -1,4 +1,5 @@
 import 'package:beamer/beamer.dart';
+import 'package:beamer_test/router.dart';
 import 'package:flutter/material.dart';
 
 class BottomNavigationScreen extends StatefulWidget {
@@ -35,7 +36,8 @@ class _BottomNavigationScreenState extends State<BottomNavigationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    _currentIndex = _beamerDelegate.configuration.location == '/foo' ? 0 : 1;
+    _currentIndex =
+        _beamerDelegate.configuration.location == AppRouter.fooRoute ? 0 : 1;
     return BottomNavigationBar(
       currentIndex: _currentIndex,
       items: const [
@@ -43,7 +45,7 @@ class _BottomNavigationScreenState extends State<BottomNavigationScreen> {
         BottomNavigationBarItem(label: 'Bar', icon: Icon(Icons.article)),
       ],
       onTap: (index) => _beamerDelegate.beamToNamed(
-        index == 0 ? '/foo' : '/bar',
+        index == 0 ? AppRouter.fooRoute : AppRouter.barRoute,
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: beamer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  beamer: 1.1.0
+  beamer: ^1.2.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
With the upgrade to version 1.2, I ran into an issue when navigating between different Beamers when the inner beamer path pattern is not matching with `/*`. 

It always goes back to the `initialPath` of the inner beamer.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/20042349/148446479-02dc1d50-4a1d-4ec7-83a7-2ed2c6add1b5.gif)

